### PR TITLE
Bugs fix

### DIFF
--- a/R/allele_qc.R
+++ b/R/allele_qc.R
@@ -125,6 +125,7 @@ allele_qc <- function(target_variants, ref_variants, target_data, col_to_flip,
     # we conclude that strand flip does not exists in the data at all
     # so we can bring back those previous marked to drop because of strand ambiguous
     snp[["keep"]][which(!strand_unambiguous)] <- TRUE
+    snp[["keep"]][!(exact_match | snp[["sign_flip"]])] <- FALSE
   }
 
   qc_summary <- matched %>%

--- a/R/allele_qc.R
+++ b/R/allele_qc.R
@@ -82,10 +82,11 @@ allele_qc <- function(target_variants, ref_variants, target_data, col_to_flip,
   matched_indices <- target_variants %>%
                      mutate(index = row_number())%>%
                      inner_join(matched, by = c("chrom" = "chrom", "pos" = "pos", "A1" = "A1.target", "A2" = "A2.target")) %>%
-                     filter(duplicated(.) | !duplicated(.)) # this will keep all rows, duplicates and non-duplicates alike
+                     filter(duplicated(.) | !duplicated(.))   # this will keep all rows, duplicates and non-duplicates alike
+  variants_id_qced = matched_indices %>% pull(variants_id_qced)
   target_data_qced <- target_data[matched_indices$index, , drop = FALSE]%>%
-                      as.data.frame()%>%
-                      mutate(variant_id = matched$variants_id_qced)
+                      as.data.frame() %>%
+                      mutate(variant_id = variants_id_qced)
   
   a1 <- toupper(matched$A1.target)
   a2 <- toupper(matched$A2.target)

--- a/R/susie_wrapper.R
+++ b/R/susie_wrapper.R
@@ -368,7 +368,8 @@ susie_rss_qc <- function(sumstat, R, ref_panel, bhat=NULL, shat=NULL, var_y=NULL
     }
     
     ## Imputation logic using RAiSS or other methods
-
+    # sumstat z have different dimension with R
+    # susie_rss_qc(sumstat, ref_panel = ref_panel, R = R, n = n, L = L
     imputation_res <- raiss(ref_panel, known_zscores, R, lamb = lamb, rcond = rcond, 
                                R2_threshold = R2_threshold, minimum_ld = minimum_ld)
       

--- a/R/susie_wrapper.R
+++ b/R/susie_wrapper.R
@@ -368,8 +368,6 @@ susie_rss_qc <- function(sumstat, R, ref_panel, bhat=NULL, shat=NULL, var_y=NULL
     }
     
     ## Imputation logic using RAiSS or other methods
-    # sumstat z have different dimension with R
-    # susie_rss_qc(sumstat, ref_panel = ref_panel, R = R, n = n, L = L
     imputation_res <- raiss(ref_panel, known_zscores, R, lamb = lamb, rcond = rcond, 
                                R2_threshold = R2_threshold, minimum_ld = minimum_ld)
       


### PR DESCRIPTION
1. using matched$variants_id_qced to assign variant_id can cause row number cannot match, so here I directly use table matched_indices to get new variant id to make sure the number of element can fit.

2. In allele flip if we make sure there is no ambiguous snps, it's good to reassign keep = TRUE to these SNPs. However, this will bring back some variants we should have filtered. For example, in target data: a1/a2 = G/C, ref1/ref2 = T/C. Then this should be removed but as a1/a2 are ambigous pair so we make it back to be kept. This is not correct. After making sure that there is no strand flip we still should remove those that are not exact match / sign flip, assigning them "keep" = false again.

Otherwise this will cause dimension not match.