### PR TITLE
Add coverage script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage-${{github.event.pull_request.head.sha}}
+          path: coverage
 
       #- name: Run R CMD CHECK
         #shell: micromamba-shell {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,14 @@ jobs:
 
       - name: Check unit test code coverage
         shell: micromamba-shell {0}
-        run: R -e "covr::package_coverage()"
+        run: |
+          .github/workflows/get_package_coverage.R
+          tar cf coverage.tar coverage
+
+      - name: Upload coverage artifact to GitHub Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-${{github.event.pull_request.head.sha}}
 
       #- name: Run R CMD CHECK
         #shell: micromamba-shell {0}

--- a/.github/workflows/get_package_coverage.R
+++ b/.github/workflows/get_package_coverage.R
@@ -1,0 +1,19 @@
+#!/usr/bin/env Rscript
+
+library(covr)
+library(jsonlite)
+library(magrittr)
+library(readr)
+
+coverage_output <- package_coverage()
+print(coverage_output)
+coverage_pct <- percent_coverage(coverage_output)
+coverage_list <- list(
+    lines = list(pct = coverage_pct),
+    statements = list(pct = coverage_pct),
+    functions = list(pct = coverage_pct),
+    branches = list(pct = coverage_pct)
+)
+coverage_list_final <- list(total = coverage_list)
+dir.create("coverage")
+toJSON(coverage_list_final) %>% write_lines("coverage/coverage-summary.json")

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,28 @@
+name: Post-merge actions
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  update_coverage_badge:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download coverage artifact
+        id: download-coverage
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ci.yml
+          name: coverage_${{ github.event.pull_request.head.sha }}
+          search_artifacts: true
+          if_no_artifact_found: warn
+
+      - name: Update Coverage Badge
+        uses: we-cli/coverage-badge-action@main

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,6 +21,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ci.yml
           name: coverage_${{ github.event.pull_request.head.sha }}
+          path: coverage
           search_artifacts: true
           if_no_artifact_found: warn
 


### PR DESCRIPTION
This PR adds the steps that should be needed for uploading a coverage badge to GitHub pages with the percent coverage whenever a PR is merged.

It consists of several steps:

1. Run an R script to get the code coverage report, print its output for viewing, and save the coverage percent to a JSON file.  The `coverage-badge-action` has a very specific format it expects for the JSON which we have to coerce our output into matching.
2. Upload this coverage JSON to GitHub Actions as a build artifact whose name contains the head SHA for the pull request branch.
3. Upon merging a pull request, the build artifact for the head SHA that was merged will be downloaded and the JSON file within the artifact will be converted to an SVG and uploaded to GitHub pages.
4. The README.MD will contain the URL to this SVG, which will be updated as soon as the page is refreshed.