### PR TITLE
add comparison on summary in the output between slalom.py and slalom.R

### DIFF
--- a/R/slalom.R
+++ b/R/slalom.R
@@ -77,7 +77,7 @@ slalom <- function(zScore, LDmat, standard_error = rep(1, length(zScore)), abf_p
   outliers <- (r2[, lead_idx] > r2_threshold) & (nlog10p_dentist_s > nlog10p_dentist_s_threshold)
   
   n_r2 <- sum(r2[, lead_idx] > r2_threshold)
-  n_dentist_s_outlier <- sum(outliers) 
+  n_dentist_s_outlier <- sum(outliers, na.rm = TRUE) 
   max_pip <- max(prob) 
   
   summary <- list( 
@@ -88,7 +88,7 @@ slalom <- function(zScore, LDmat, standard_error = rep(1, length(zScore)), abf_p
     fraction = ifelse(n_r2 > 0, n_dentist_s_outlier / n_r2, 0), 
     max_pip = max_pip,
     cs_95 = cs,
-    cs_99 = cs_99 
+    cs_99 = cs_99
   ) 
   result <- as.data.frame(list(original_z = zScore, prob = prob, pvalue = pvalue, outliers = outliers, nlog10p_dentist_s = nlog10p_dentist_s))
   

--- a/inst/prototype/slalom_R_python_comparison.ipynb
+++ b/inst/prototype/slalom_R_python_comparison.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 198,
    "id": "8d5f9061-bbbe-42ee-889d-1eb687950627",
    "metadata": {
     "kernel": "Python3",
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 199,
    "id": "9eaad80f-437e-4ac9-ac4c-e75bbe89be73",
    "metadata": {
     "kernel": "Python3",
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 200,
    "id": "479a834a-e2d0-40a3-b3ee-19b992cef287",
    "metadata": {
     "kernel": "Python3",
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 201,
    "id": "0b2fe2ef-7ceb-46d4-9d2f-303575308fe5",
    "metadata": {
     "kernel": "Python3",
@@ -215,7 +215,7 @@
        "4  1.658588  0.951401  "
       ]
      },
-     "execution_count": 54,
+     "execution_count": 201,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 202,
    "id": "a77f55e0-4820-427c-914b-4820f3fae1a2",
    "metadata": {
     "kernel": "Python3",
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 203,
    "id": "1967b53f-b0fb-4f2b-8a3c-4ce4d42cabc4",
    "metadata": {
     "kernel": "Python3",
@@ -281,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 204,
    "id": "70384b8d-2389-4b1f-b08b-886c2948fad6",
    "metadata": {
     "kernel": "Python3",
@@ -456,13 +456,56 @@
        "4  0.012761     2.916960           1.057234  "
       ]
      },
-     "execution_count": 61,
+     "execution_count": 204,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 205,
+   "id": "8b08567e-5b8d-4897-84db-74f5ffc5b893",
+   "metadata": {
+    "kernel": "Python3",
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n_r2=22\n",
+      "n_dentist_s_outlier=21\n",
+      "max_pip=0.0013062877743510654\n"
+     ]
+    }
+   ],
+   "source": [
+    "df[\"r2\"] = df.r ** 2\n",
+    "\n",
+    "# case_control = TRUE for effective samples\n",
+    "# if args.case_control:\n",
+    "#     df[\"n_eff_samples\"] = df.n_samples * (df.n_cases / df.n_samples) * (1 - df.n_cases / df.n_samples)\n",
+    "# else:\n",
+    "#     df[\"n_eff_samples\"] = df.n_samples\n",
+    "\n",
+    "# manual set r2_threshold and nlog10p_dentist_s_threshold (according to R function)\n",
+    "r2_threshold = 0.6\n",
+    "nlog10p_dentist_s_threshold = 4.0\n",
+    "n_r2 = np.sum(df.r2 > r2_threshold)\n",
+    "print(f\"n_r2={n_r2}\")\n",
+    "\n",
+    "n_dentist_s_outlier = np.sum(\n",
+    "    (df.r2 > r2_threshold) & (df.nlog10p_dentist_s > nlog10p_dentist_s_threshold)\n",
+    ")\n",
+    "print(f\"n_dentist_s_outlier={n_dentist_s_outlier}\")\n",
+    "\n",
+    "max_pip = np.max(df.prob)\n",
+    "print(f\"max_pip={max_pip}\")"
    ]
   },
   {
@@ -477,7 +520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 209,
    "id": "431a2822-8035-4644-925b-3013ec08b470",
    "metadata": {
     "kernel": "R",
@@ -494,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 210,
    "id": "9d471bc8-4d2f-40e0-86d5-e09d27345e53",
    "metadata": {
     "kernel": "R",
@@ -509,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 211,
    "id": "eb803f58-0bd8-41bc-b118-edb6dd6a3321",
    "metadata": {
     "kernel": "R",
@@ -522,7 +565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 212,
    "id": "9098432c-5b93-472f-ba9a-e8b543d65fc2",
    "metadata": {
     "kernel": "R",
@@ -535,8 +578,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
-   "id": "4d43d86b-d16c-4f08-b0bf-81f8f34d02bb",
+   "execution_count": 213,
+   "id": "38a5ab35-8276-4864-b10e-8f2aca464c37",
    "metadata": {
     "kernel": "R",
     "tags": []
@@ -601,7 +644,21 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
+    }
+   ],
+   "source": [
+    "head(results$data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 214,
+   "id": "4d43d86b-d16c-4f08-b0bf-81f8f34d02bb",
+   "metadata": {
+    "kernel": "R",
+    "tags": []
+   },
+   "outputs": [
     {
      "data": {
       "text/html": [
@@ -613,9 +670,9 @@
        "\t<dt>$n_r2</dt>\n",
        "\t\t<dd>22</dd>\n",
        "\t<dt>$n_dentist_s_outlier</dt>\n",
-       "\t\t<dd>&lt;NA&gt;</dd>\n",
+       "\t\t<dd>21</dd>\n",
        "\t<dt>$fraction</dt>\n",
-       "\t\t<dd>&lt;NA&gt;</dd>\n",
+       "\t\t<dd>0.954545454545455</dd>\n",
        "\t<dt>$max_pip</dt>\n",
        "\t\t<dd>0.00130628777435107</dd>\n",
        "\t<dt>$cs_95</dt>\n",
@@ -641,8 +698,8 @@
        "\\item[\\$lead\\_pip\\_variant] 203\n",
        "\\item[\\$n\\_total] 1000\n",
        "\\item[\\$n\\_r2] 22\n",
-       "\\item[\\$n\\_dentist\\_s\\_outlier] <NA>\n",
-       "\\item[\\$fraction] <NA>\n",
+       "\\item[\\$n\\_dentist\\_s\\_outlier] 21\n",
+       "\\item[\\$fraction] 0.954545454545455\n",
        "\\item[\\$max\\_pip] 0.00130628777435107\n",
        "\\item[\\$cs\\_95] \\begin{enumerate*}\n",
        "\\item 203\n",
@@ -1462,9 +1519,9 @@
        "$n_r2\n",
        ":   22\n",
        "$n_dentist_s_outlier\n",
-       ":   &lt;NA&gt;\n",
+       ":   21\n",
        "$fraction\n",
-       ":   &lt;NA&gt;\n",
+       ":   0.954545454545455\n",
        "$max_pip\n",
        ":   0.00130628777435107\n",
        "$cs_95\n",
@@ -2291,10 +2348,10 @@
        "[1] 22\n",
        "\n",
        "$n_dentist_s_outlier\n",
-       "[1] NA\n",
+       "[1] 21\n",
        "\n",
        "$fraction\n",
-       "[1] NA\n",
+       "[1] 0.9545455\n",
        "\n",
        "$max_pip\n",
        "[1] 0.001306288\n",
@@ -2439,7 +2496,6 @@
     }
    ],
    "source": [
-    "head(results$data)\n",
     "results$summary"
    ]
   },
@@ -2450,8 +2506,18 @@
     "kernel": "R"
    },
    "source": [
-    "Note that the `t_dentist_s`, `pvalue` and `nlog10p_dentist_s` variables are consistent between the results in R and python."
+    "Note that the `t_dentist_s`, `pvalue` and `nlog10p_dentist_s` variables are consistent between the results in R and python for the variants. And the `max_pip`, `n_r2` and `n_dentist_s_outlier` are also consistent."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "168d9d89-dced-4fb3-a8db-fa8bd5477857",
+   "metadata": {
+    "kernel": "R"
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
also fix the NA issue in the R code for this line:
```R
t_dentist_s <- (zScore - LDmat[, lead_idx] * zScore[lead_idx])^2 / (1 - r2[, lead_idx])
# ...
n_dentist_s_outlier <- sum(outliers, na.rm = TRUE) 
```
For the lead_idx, the t_dentist_s value would be NA because the r2 is 1. Thus the `n_dentist_s_outlier` would be NA. Therefore we add `na.rm=TRUE` in the sum command to avoid the issue.

The results are consistent between `slalom.py` and `slalom.R`.