### PR TITLE
Add unit tests for twas_scan and encoloc

### DIFF
--- a/R/encoloc.R
+++ b/R/encoloc.R
@@ -122,7 +122,7 @@ calculate_purity <- function(variants, ext_ld, squared) {
 #' 2. PPH4 exceeds threshold, default as 0.8.
 #' 3. We aggregate variants and cumulatively sum their PPH4 values to form a credible set until the threshold, default as 0.95.
 #' 4. The cs's purity is computed with the `get_purity` function from the `gaow/susieR` package, and the same purity criteria are employed to filter the credibility set.
-process_coloc_results <- function(coloc_result, LD_meta_file_path, analysis_script_obj, PPH4_thres = 0.8, coloc_pip_thres = 0.95, squared = FALSE, min_abs_corr = 0.5, null_index = 0, coloc_index = "PP.H4.abf", analysis_region, median_abs_corr = NULL) {
+process_coloc_results <- function(coloc_result, LD_meta_file_path, analysis_script_obj, analysis_region, PPH4_thres = 0.8, coloc_pip_thres = 0.95, squared = FALSE, min_abs_corr = 0.5, null_index = 0, coloc_index = "PP.H4.abf", median_abs_corr = NULL) {
   # Extract PIP values from coloc_result summary
   coloc_summary <- as.data.frame(coloc_result$summary)
   coloc_pip <- coloc_summary[, grepl("PP", colnames(coloc_summary))]

--- a/man/allele_qc.Rd
+++ b/man/allele_qc.Rd
@@ -27,7 +27,7 @@ allele_qc(
 
 \item{remove_dups}{Whether to remove duplicates, default is TRUE.}
 
-\item{flip}{Whether the alleles must be flipped: A <--> T & C <--> G, in which case 
+\item{flip}{Whether the alleles must be flipped: A <--> T & C <--> G, in which case
 corresponding `col_to_flip` are multiplied by -1. Default is `TRUE`.}
 
 \item{remove_indels}{Whether to remove INDELs, default is FALSE.}

--- a/man/coloc_wrapper.Rd
+++ b/man/coloc_wrapper.Rd
@@ -37,7 +37,7 @@ coloc_wrapper(
 
 \item{gwas_region_obj}{Optional table name in GWAS RDS files (default 'susie_fit').}
 
-\item{prior_tol}{When the prior variance is estimated, compare the estimated value to \code{prior_tol} at the end of the computation, 
+\item{prior_tol}{When the prior variance is estimated, compare the estimated value to \code{prior_tol} at the end of the computation,
 and exclude a single effect from PIP computation if the estimated prior variance is smaller than this tolerance value.}
 
 \item{p1, }{p2, and p12 are results from xqtl_enrichment_wrapper (default 'p1=1e-4, p2=1e-4, p12=5e-6', same as coloc.bf_bf).}

--- a/man/compute_qtl_enrichment.Rd
+++ b/man/compute_qtl_enrichment.Rd
@@ -19,12 +19,12 @@ compute_qtl_enrichment(
 
 \item{susie_qtl_regions}{This is a list of SuSiE fitted objects per QTL unit analyzed}
 
-\item{pi_gwas}{This parameter is highly important if GWAS input does not contain all SNPs interrogated (e.g., in some cases, only fine-mapped geomic regions are included). 
+\item{pi_gwas}{This parameter is highly important if GWAS input does not contain all SNPs interrogated (e.g., in some cases, only fine-mapped geomic regions are included).
 Then users must pick a value of total_variants and estimate pi_gwas beforehand by: sum(gwas_pip$pip)/total_variants}
 
 \item{pi_qtl}{This parameter can be safely left to default if your input QTL data has enough regions to estimate it.}
 
-\item{lambda}{Similar to the shrinkage parameter used in ridge regression. It takes any non-negative value and shrinks the enrichment estimate towards 0. 
+\item{lambda}{Similar to the shrinkage parameter used in ridge regression. It takes any non-negative value and shrinks the enrichment estimate towards 0.
 When it is set to 0, no shrinkage will be applied. A large value indicates strong shrinkage. The default value is set to 1.0.}
 
 \item{ImpN}{Rounds of multiple imputation to draw QTL from, default is 25.}
@@ -35,7 +35,7 @@ When it is set to 0, no shrinkage will be applied. A large value indicates stron
 A list of enrichment parameter estimates
 }
 \description{
-Largely follows from fastenloc https://github.com/xqwen/fastenloc 
+Largely follows from fastenloc https://github.com/xqwen/fastenloc
 but uses `susieR` fitted objects as input to estimate prior for use with `coloc` package (coloc v5, aka SuSiE-coloc).
 The main differences are 1) now enrichment is based on all QTL variants whether or not they are inside signal clusters;
 2) Causal QTL are sampled from SuSiE single effects, not signal clusters;
@@ -52,21 +52,21 @@ Uses output of \code{\link[susieR]{susie}} from the
 n_gwas_pip <- 1000
 gwas_pip <- runif(n_gwas_pip)
 names(gwas_pip) <- paste0("snp", 1:n_gwas_pip)
-gwas_fit <- list(pip=gwas_pip)
+gwas_fit <- list(pip = gwas_pip)
 # Simulate fake data for a single SuSiEFit object
 simulate_susiefit <- function(n, p) {
- pip <- runif(n)
- names(pip) <- paste0("snp", 1:n)
- alpha <- t(matrix(runif(n * p), nrow = n))
- alpha <- t(apply(alpha, 1, function(row) row / sum(row)))
- list(
-   pip = pip,
-   alpha = alpha,
-   prior_variance = runif(p)
- )
+  pip <- runif(n)
+  names(pip) <- paste0("snp", 1:n)
+  alpha <- t(matrix(runif(n * p), nrow = n))
+  alpha <- t(apply(alpha, 1, function(row) row / sum(row)))
+  list(
+    pip = pip,
+    alpha = alpha,
+    prior_variance = runif(p)
+  )
 }
 # Simulate multiple SuSiEFit objects
-n_susie_fits <- 2 
+n_susie_fits <- 2
 susie_fits <- replicate(n_susie_fits, simulate_susiefit(n_gwas_pip, 10), simplify = FALSE)
 # Add these fits to a list, providing names to each element
 names(susie_fits) <- paste0("fit", 1:length(susie_fits))

--- a/man/load_LD_matrix.Rd
+++ b/man/load_LD_matrix.Rd
@@ -7,8 +7,8 @@
 load_LD_matrix(LD_meta_file_path, region, extract_coordinates = NULL)
 }
 \arguments{
-\item{LD_meta_file_path}{path of LD_metadata, LD_metadata is a data frame specifying LD blocks with 
-columns "chrom", "start", "end", and "path". "start" and "end" denote the positions of LD blocks. 
+\item{LD_meta_file_path}{path of LD_metadata, LD_metadata is a data frame specifying LD blocks with
+columns "chrom", "start", "end", and "path". "start" and "end" denote the positions of LD blocks.
 "path" is the path of each LD block, optionally including bim file paths.}
 
 \item{region}{A data frame specifying region of interest with columns "chrom", "start", and "end".}
@@ -19,7 +19,7 @@ columns "chrom", "start", "end", and "path". "start" and "end" denote the positi
 A list of processed LD matrices and associated variant data frames for region of interest.
 Each element of the list contains:
 \describe{
-\item{combined_LD_variants}{A data frame merging selected variants within each LD block in bim file format with columns "chrom", "variants", 
+\item{combined_LD_variants}{A data frame merging selected variants within each LD block in bim file format with columns "chrom", "variants",
 "GD", "pos", "A1", and "A2".}
 \item{combined_LD_matrix}{The LD matrix for each region, with row and column names matching variant identifiers.}
 }

--- a/man/load_twas_weights.Rd
+++ b/man/load_twas_weights.Rd
@@ -14,7 +14,7 @@ load_twas_weights(
 \arguments{
 \item{variable_name_obj}{The name of the variable/object to fetch from each file, if not NULL.}
 
-\item{weight_db_file}{weight_db_files Vector of file paths for RDS files containing TWAS weights.. 
+\item{weight_db_file}{weight_db_files Vector of file paths for RDS files containing TWAS weights..
 Each element organized as region/condition/weights}
 
 \item{condition}{The specific condition to be checked and consolidated across all files.}

--- a/man/mr_ash_rss.Rd
+++ b/man/mr_ash_rss.Rd
@@ -96,21 +96,27 @@ yty <- t(y) \%*\% y
 # Set the prior
 K <- 9
 sigma0 <- c(0.001, .1, .5, 1, 5, 10, 20, 30, .005)
-omega0 <- rep(1/K, K)
+omega0 <- rep(1 / K, K)
 
 # Calculate summary statistics
-b.hat <- sapply(1:p, function(j) { summary(lm(y ~ X[, j]))$coefficients[-1, 1] })
-s.hat <- sapply(1:p, function(j) { summary(lm(y ~ X[, j]))$coefficients[-1, 2] })
+b.hat <- sapply(1:p, function(j) {
+  summary(lm(y ~ X[, j]))$coefficients[-1, 1]
+})
+s.hat <- sapply(1:p, function(j) {
+  summary(lm(y ~ X[, j]))$coefficients[-1, 2]
+})
 R.hat <- cor(X)
 var_y <- var(y)
 sigmasq_init <- 1.5
 
 # Run mr_ash_rss
-out <- mr_ash_rss(b.hat, s.hat, R = R.hat, var_y = var_y, n = n,
-                  sigma2_e = sigmasq_init, s0 = sigma0, w0 = omega0,
-                  mu1_init = rep(0, ncol(X)), tol = 1e-8, max_iter = 1e5,
-                  update_w0 = TRUE, update_sigma = TRUE, compute_ELBO = TRUE,
-                  standardize = FALSE)
+out <- mr_ash_rss(b.hat, s.hat,
+  R = R.hat, var_y = var_y, n = n,
+  sigma2_e = sigmasq_init, s0 = sigma0, w0 = omega0,
+  mu1_init = rep(0, ncol(X)), tol = 1e-8, max_iter = 1e5,
+  update_w0 = TRUE, update_sigma = TRUE, compute_ELBO = TRUE,
+  standardize = FALSE
+)
 # In sample prediction correlations
-cor(X\%*\%out1$mu1, y) # 0.9984064
+cor(X \%*\% out1$mu1, y) # 0.9984064
 }

--- a/man/process_coloc_results.Rd
+++ b/man/process_coloc_results.Rd
@@ -13,13 +13,13 @@ process_coloc_results(
   coloc_result,
   LD_meta_file_path,
   analysis_script_obj,
+  analysis_region,
   PPH4_thres = 0.8,
   coloc_pip_thres = 0.95,
   squared = FALSE,
   min_abs_corr = 0.5,
   null_index = 0,
   coloc_index = "PP.H4.abf",
-  analysis_region,
   median_abs_corr = NULL
 )
 }

--- a/man/prs_cs.Rd
+++ b/man/prs_cs.Rd
@@ -78,19 +78,23 @@ yty <- t(y) \%*\% y
 # Set the prior
 K <- 9
 sigma0 <- c(0.001, .1, .5, 1, 5, 10, 20, 30, .005)
-omega0 <- rep(1/K, K)
+omega0 <- rep(1 / K, K)
 
 # Calculate summary statistics
-b.hat <- sapply(1:p, function(j) { summary(lm(y ~ X[, j]))$coefficients[-1, 1] })
-s.hat <- sapply(1:p, function(j) { summary(lm(y ~ X[, j]))$coefficients[-1, 2] })
+b.hat <- sapply(1:p, function(j) {
+  summary(lm(y ~ X[, j]))$coefficients[-1, 1]
+})
+s.hat <- sapply(1:p, function(j) {
+  summary(lm(y ~ X[, j]))$coefficients[-1, 2]
+})
 R.hat <- cor(X)
 var_y <- var(y)
 sigmasq_init <- 1.5
 
 # Run PRS CS
-maf = rep(0.5, length(b.hat)) # fake MAF
+maf <- rep(0.5, length(b.hat)) # fake MAF
 LD <- list(blk1 = R.hat)
-out <- prs_cs(b.hat, LD, n, maf=maf)
+out <- prs_cs(b.hat, LD, n, maf = maf)
 # In sample prediction correlations
-cor(X\%*\%out$beta_est, y) # 0.9944553
+cor(X \%*\% out$beta_est, y) # 0.9944553
 }

--- a/man/slalom.Rd
+++ b/man/slalom.Rd
@@ -41,7 +41,7 @@ A list containing the annotated LD matrix with ABF results, credible sets,
 }
 \description{
 Performs Approximate Bayesian Factor (ABF) analysis, identifies credible sets,
-and annotates lead variants based on fine-mapping results. It computes p-values 
+and annotates lead variants based on fine-mapping results. It computes p-values
 from z-scores assuming a two-sided standard normal distribution.
 }
 \examples{

--- a/man/twas_weights.Rd
+++ b/man/twas_weights.Rd
@@ -11,7 +11,7 @@ twas_weights(X, Y, weight_methods, num_threads = 1, seed = NULL)
 
 \item{Y}{A matrix (or vector, which will be converted to a matrix) of samples by outcomes, where each row corresponds to a sample.}
 
-\item{weight_methods}{A list of methods and their specific arguments, formatted as list(method1 = method1_args, method2 = method2_args). 
+\item{weight_methods}{A list of methods and their specific arguments, formatted as list(method1 = method1_args, method2 = method2_args).
 methods in the list are applied to the datasets X and Y.}
 
 \item{num_threads}{The number of threads to use for parallel processing.

--- a/man/twas_weights_cv.Rd
+++ b/man/twas_weights_cv.Rd
@@ -22,13 +22,13 @@ twas_weights_cv(
 
 \item{Y}{A matrix (or vector, which will be converted to a matrix) of samples by outcomes, where each row corresponds to a sample.}
 
-\item{fold}{An optional integer specifying the number of folds for cross-validation. 
+\item{fold}{An optional integer specifying the number of folds for cross-validation.
 If NULL, 'sample_partitions' must be provided.}
 
-\item{sample_partitions}{An optional dataframe with predefined sample partitions, 
+\item{sample_partitions}{An optional dataframe with predefined sample partitions,
 containing columns 'Sample' (sample names) and 'Fold' (fold number). If NULL, 'fold' must be provided.}
 
-\item{weight_methods}{A list of methods and their specific arguments, formatted as list(method1 = method1_args, method2 = method2_args). 
+\item{weight_methods}{A list of methods and their specific arguments, formatted as list(method1 = method1_args, method2 = method2_args).
 methods in the list can be either univariate (applied to each column of Y) or multivariate (applied to the entire Y matrix).}
 
 \item{seed}{An optional integer to set the random seed for reproducibility of sample splitting.}
@@ -59,7 +59,7 @@ A list with the following components:
 }
 }
 \description{
-Performs cross-validation for TWAS, supporting both univariate and multivariate methods. 
-It can either create folds for cross-validation or use pre-defined sample partitions. 
+Performs cross-validation for TWAS, supporting both univariate and multivariate methods.
+It can either create folds for cross-validation or use pre-defined sample partitions.
 For multivariate methods, it applies the method to the entire Y matrix for each fold.
 }

--- a/tests/testthat/test_encoloc.R
+++ b/tests/testthat/test_encoloc.R
@@ -1,5 +1,70 @@
 context("encoloc")
 library(tidyverse)
+library(coloc)
+
+generate_mock_ld_files <- function(seed = 1, num_blocks = 5) {
+    data(coloc_test_data)
+    attach(coloc_test_data)
+    set.seed(seed)
+
+    # Generate mock LD files
+    blocks <- seq(100, num_blocks*100, 100)
+    ld_blocks <- lapply(
+        blocks,
+        function(i) {
+            variants <- paste0("s", (i-100+1):i)
+            ld_block <- as.data.frame(D1$LD[variants, variants])
+            return(ld_block)
+    })
+
+    bim_files <- lapply(
+        blocks,
+        function(i) {
+            bim_df <- data.frame(
+                chrom = "chr1",
+                id = paste0("chr1:", (i-100+1):i, "_A_G"),
+                rand = 0,
+                pos = (i-100+1):i,
+                ref = "A",
+                alt = "G"
+            )
+            return(bim_df)
+        }
+    )
+
+    bim_paths <- lapply(blocks, function(i) {
+        gsub("//", "/", tempfile(pattern = paste0("LD_block_", i/100, ".chr1_", i-100+1, "_", i, ".float16"), tmpdir = tempdir(), fileext = ".bim"))
+    })
+
+    ld_paths <- lapply(blocks, function(i) {
+        gsub("//", "/", tempfile(pattern = paste0("LD_block_", i/100, ".chr1_", i-100+1, "_", i, ".float16"), tmpdir = tempdir(), fileext = ".txt.xz"))
+    })
+
+    lapply(
+        1:num_blocks,
+        function(i) {
+            xzfile <- xzfile(ld_paths[[i]], "wb")
+            write_delim(ld_blocks[[i]], xzfile, delim = "\t", col_names = FALSE)
+            close(xzfile)
+        })
+
+    lapply(
+        1:num_blocks,
+        function(i) {
+            write_delim(bim_files[[i]], bim_paths[[i]], delim = "\t", col_names = FALSE)
+        })
+    
+    meta_df <- data.frame(
+        chrom = "chr1",
+        start = seq(1, 401, 100),
+        end = seq(100, 500, 100),
+        path = unlist(lapply(1:num_blocks, function(i) paste0(ld_paths[[i]], ",", bim_paths[[i]]))))
+    
+    meta_path <- gsub("//", "/", tempfile(pattern = paste0("ld_meta_file_path"), tmpdir = tempdir(), fileext = ".txt.gz"))
+    write_delim(meta_df, meta_path, delim = "\t")
+
+    return(list(ld_paths = ld_paths, bim_paths = bim_paths, meta_path = meta_path))
+}
 
 generate_mock_data_for_enrichment <- function(seed=1, num_files=2) {
     gwas_finemapped_data <- as.vector(paste0("gwas_file", 1:num_files))
@@ -123,3 +188,121 @@ test_that("coloc_wrapper works with dummy input",{
 })
 
 test_that("coloc_wrapper error with non-unique",{ })
+
+test_that("filter_and_order_coloc_results raises error with insufficient columns",{
+    expect_error(filter_and_order_coloc_results(data.frame()))
+})
+
+test_that("filter_and_order_coloc_results works with dummy data",{
+    data(coloc_test_data)
+    attach(coloc_test_data)
+    data <- generate_mock_ld_files()
+    region <- "chr1:1-500"
+    B1 <- D1
+    B2 <- D2
+    B1$snp <- B2$snp <- colnames(B1$LD) <- colnames(B2$LD) <- rownames(B1$LD) <- rownames(B2$LD) <- paste0("1:", 1:500, ":A:G")
+    mock_coloc_results <- coloc.signals(B1, B2, p12 = 1e-5)
+    # Mimic the path to using filter_and_order_coloc_results
+    coloc_summary <- as.data.frame(mock_coloc_results$summary)
+    coloc_pip <- coloc_summary[, grepl("PP", colnames(coloc_summary))]
+    PPH4_thres <- 0.8
+    coloc_index <- "PP.H4.abf"
+    coloc_results_df <- as.data.frame(mock_coloc_results$results)
+    coloc_filter <- apply(coloc_pip, 1, function(row) {
+        max_index <- which.max(row)
+        max_value <- row[max_index]
+        return(max_value > PPH4_thres && colnames(coloc_pip)[max_index] == coloc_index)
+    })
+    coloc_results_fil <- coloc_results_df[, c(1, which(coloc_filter) + 1), drop = FALSE]
+    coloc_summary_fil <- coloc_summary[which(coloc_filter),, drop = FALSE]
+    ordered_results <- filter_and_order_coloc_results(coloc_results_fil)
+    expect_equal(length(ordered_results), 1)
+    lapply(unlist(data), function(x) {
+        file.remove(x)
+    })
+})
+
+test_that("calculate_cumsum works with dummy data", {
+    data(coloc_test_data)
+    attach(coloc_test_data)
+    data <- generate_mock_ld_files()
+    region <- "chr1:1-500"
+    B1 <- D1
+    B2 <- D2
+    B1$snp <- B2$snp <- colnames(B1$LD) <- colnames(B2$LD) <- rownames(B1$LD) <- rownames(B2$LD) <- paste0("1:", 1:500, ":A:G")
+    mock_coloc_results <- coloc.signals(B1, B2, p12 = 1e-5)
+    # Mimic the path to using filter_and_order_coloc_results
+    coloc_summary <- as.data.frame(mock_coloc_results$summary)
+    coloc_pip <- coloc_summary[, grepl("PP", colnames(coloc_summary))]
+    PPH4_thres <- 0.8
+    coloc_index <- "PP.H4.abf"
+    coloc_results_df <- as.data.frame(mock_coloc_results$results)
+    coloc_filter <- apply(coloc_pip, 1, function(row) {
+        max_index <- which.max(row)
+        max_value <- row[max_index]
+        return(max_value > PPH4_thres && colnames(coloc_pip)[max_index] == coloc_index)
+    })
+    coloc_results_fil <- coloc_results_df[, c(1, which(coloc_filter) + 1), drop = FALSE]
+    coloc_summary_fil <- coloc_summary[which(coloc_filter),, drop = FALSE]
+    ordered_results <- filter_and_order_coloc_results(coloc_results_fil)
+    cs <- list()
+    
+    for (n in 1:length(ordered_results)) {
+      tmp_coloc_results_fil <- ordered_results[[n]]
+      tmp_coloc_results_fil_csm <- calculate_cumsum(tmp_coloc_results_fil)
+      expect_equal(tmp_coloc_results_fil_csm, cumsum(tmp_coloc_results_fil[,2]))  
+    }
+    lapply(unlist(data), function(x) {
+        file.remove(x)
+    })
+})
+
+test_that("load_and_extract_ld_matrix works with dummy data", {
+    data(coloc_test_data)
+    attach(coloc_test_data)
+    data <- generate_mock_ld_files()
+    region <- "chr1:1-5"
+    B1 <- D1
+    B2 <- D2
+    B1$snp <- B2$snp <- colnames(B1$LD) <- colnames(B2$LD) <- rownames(B1$LD) <- rownames(B2$LD) <- paste0("1:", 1:500, ":A:G")
+    variants <- paste0("1:", 1:5, ":A:G")
+    res <- load_and_extract_ld_matrix(data$meta_path, region, variants)
+    expect_equal(nrow(res), 5)
+    expect_equal(ncol(res), 5)
+    lapply(unlist(data), function(x) {
+        file.remove(x)
+    })
+})
+
+test_that("calculate_purity works with dummy data", {
+    data(coloc_test_data)
+    attach(coloc_test_data)
+    data <- generate_mock_ld_files()
+    region <- "chr1:1-5"
+    B1 <- D1
+    B2 <- D2
+    B1$snp <- B2$snp <- colnames(B1$LD) <- colnames(B2$LD) <- rownames(B1$LD) <- rownames(B2$LD) <- paste0("1:", 1:500, ":A:G")
+    variants <- paste0("1:", 1:5, ":A:G")
+    ext_ld <- load_and_extract_ld_matrix(data$meta_path, region, variants)
+    res <- calculate_purity(variants, ext_ld, squared = TRUE)
+    expect_equal(ncol(res), 3)
+    lapply(unlist(data), function(x) {
+        file.remove(x)
+    })
+})
+
+test_that("process_coloc_results works with dummy data", {
+    data(coloc_test_data)
+    attach(coloc_test_data)
+    data <- generate_mock_ld_files()
+    region <- "chr1:1-500"
+    B1 <- D1
+    B2 <- D2
+    B1$snp <- B2$snp <- colnames(B1$LD) <- colnames(B2$LD) <- rownames(B1$LD) <- rownames(B2$LD) <- paste0("1:", 1:500, ":A:G")
+    mock_coloc_results <- coloc.signals(B1, B2, p12 = 1e-5)
+    res <- process_coloc_results(mock_coloc_results, data$meta_path, "dummy_analysis_obj", region)
+    expect_equal(length(res$sets$cs), 1)
+    lapply(unlist(data), function(x) {
+        file.remove(x)
+    })
+})

--- a/tests/testthat/test_twas_scan.R
+++ b/tests/testthat/test_twas_scan.R
@@ -66,6 +66,49 @@ generate_mock_data <- function(seed=1, num_snps=100, empty_sets = F, gwas_mismat
     extract_variants_objs = extract_variants_objs))
 }
 
+mock_weights_db <- function(seed = 1, region = "chr1:100-200", condition = "monocytes", has_variable_names = TRUE, var_row_lengths = FALSE, same_gene = TRUE) {
+  if (same_gene) set.seed(1) else set.seed(seed)
+  gene <- paste0("ENSG000000000", sample(seq(100,999), 1))
+  if (var_row_lengths) {
+    if (same_gene) set.seed(seed) else set.seed(1)
+    n_variants <- sample(100:150, 1)
+    r_variants <- sort(sample(0:200, n_variants))
+  } else {
+    r_variants <- sort(sample(0:200, 100))
+    if (same_gene) set.seed(seed) else set.seed(1)
+  }
+
+  # Define mock data
+  #weights <- matrix(runif(100), ncol = 10) # Adjust size as needed
+  variant_names <- if (has_variable_names) paste0("variant_", r_variants) else NULL
+  #colnames(weights) <- rownames(weights) <- variant_names
+  susie_result_trimmed <- runif(10) # Example data
+  top_loci <- sample(r_variants, 5) # Example data
+  region_info <- list(region = region, condition = condition)
+  
+  # Combine data into a list
+  weights_db_data <- list(
+    region_info = region_info,
+    preset_variants_result = list(
+      variant_names = variant_names,
+      susie_result_trimmed = susie_result_trimmed,
+      top_loci = top_loci
+    ),
+    twas_weights = list(
+      model_one_weights = runif(length(variant_names)),
+      model_two_weights = runif(length(variant_names)),
+      model_three_weights = runif(length(variant_names)),
+      variant_names = variant_names
+    )
+  )
+  weights_db <- list(random_gene = list(condition = weights_db_data))
+  names(weights_db$random_gene) <- condition
+  names(weights_db) <- gene
+  
+  # Save the list as an RDS file
+  return(weights_db)
+}
+
 test_that("Confirm twas_scan works with simulated data",{
   data <- generate_mock_data()
   res <- twas_analysis(data$weights_all_matrix, data$gwas_sumstats_db, data$LD_matrix, data$extract_variants_objs)
@@ -87,4 +130,78 @@ test_that("twas_analysis raises error if specified variants are not in LD_matrix
     twas_analysis(data$weights_matrix, data$gwas_sumstats_db, data$LD_matrix, data$extract_variants_objs),
     "None of the specified variants are present in the LD matrix."
   )
+})
+
+setup_weight_db_vector <- function(seed = 1, n_rds = 2, n_cond = 4, condition = NA, same_condition = FALSE, same_gene = TRUE, var_row_lengths = FALSE) {
+  set.seed(seed)
+  weight_db_vector <- lapply(1:n_rds, function(i) {
+    cond <- if (same_condition) condition else gsub(", ", "", toString(sample(LETTERS, 3)))
+    mock_weights_db(seed = i, condition = cond, same_gene = same_gene, var_row_lengths = var_row_lengths)
+  })
+
+  weight_db_paths <- lapply(1:n_rds, function(i) {
+    weight_db_path <- gsub("//", "/", tempfile(pattern = paste0("weights_db_", i), tmpdir = tempdir(), fileext = ".RDS"))
+    saveRDS(weight_db_vector[[i]], weight_db_path)
+    return(weight_db_path)
+  })
+
+  return(list(weight_vec = weight_db_vector, weight_paths = weight_db_paths))
+}
+
+cleanup_weight_db_vector <- function(weight_db_paths) {
+  lapply(weight_db_paths, file.remove)
+}
+
+# Test unique regions
+test_that("load_twas_weights raises error if different regions specified", {
+  weight_db <- setup_weight_db_vector(n_rds = 2, n_cond = 4, same_gene = FALSE)
+  expect_true(
+    inherits(
+      load_twas_weights(weight_db$weight_paths, conditions = NULL, variable_name_obj = "variant_names"),
+      "try-error"))
+  cleanup_weight_db_vector(weight_db$weight_paths)
+})
+
+# Test unique regions
+test_that("load_twas_weights raises error if different number of conditions per rds file", {
+  weight_db <- setup_weight_db_vector(n_rds = 2, n_cond = 4)
+  expect_true(
+    inherits(
+      load_twas_weights(weight_db$weight_paths, conditions = "not_found", variable_name_obj = "variant_names"),
+      "try-error"))
+  cleanup_weight_db_vector(weight_db$weight_paths)
+})
+
+# Test null conditions
+test_that("load_twas_weights works with null condition", {
+  weight_db <- setup_weight_db_vector(n_rds = 2, n_cond = 4)
+  res <- load_twas_weights(weight_db$weight_paths, conditions = NULL, variable_name_obj = "variant_names")
+  expect_true(all(c("susie_results", "weights") %in% names(res)))
+  cleanup_weight_db_vector(weight_db$weight_paths)
+})
+
+# Specify conditions
+test_that("load_twas_weights works with specified condition", {
+  weight_db <- setup_weight_db_vector(n_rds = 2, n_cond = 4, same_condition = TRUE, condition = "cond_1_joe_eQTL")
+  res <- load_twas_weights(weight_db$weight_paths, conditions = "cond_1_joe_eQTL", variable_name_obj = "variant_names")
+  expect_true(all(c("susie_results", "weights") %in% names(res)))
+  cleanup_weight_db_vector(weight_db$weight_paths)
+})
+
+# Test null variable_name_obj
+test_that("load_twas_weights works with null variable_name_obj", {
+  weight_db <- setup_weight_db_vector(n_rds = 2, n_cond = 4)
+  res <- load_twas_weights(weight_db$weight_paths, conditions = NULL, variable_name_obj = NULL)
+  expect_true(all(c("susie_results", "weights") %in% names(res)))
+  cleanup_weight_db_vector(weight_db$weight_paths)
+})
+
+# Test different number of rows per condition
+test_that("load_twas_weights raises error with null variable_name_obj and variable row lengths", {
+  weight_db <- setup_weight_db_vector(n_rds = 2, n_cond = 4, var_row_lengths = TRUE)
+  expect_true(
+    inherits(
+      load_twas_weights(weight_db$weight_paths, conditions = NULL, variable_name_obj = NULL),
+      "try-error"))
+  cleanup_weight_db_vector(weight_db$weight_paths)
 })


### PR DESCRIPTION
- Increase coverage for the `twas_scan` and `encoloc` scripts. 
- The change I made in the `encoloc.R` script is just in the arrangement of variables in the function definition. It's a little awkward to have parameters with no defaults come after parameters with default values
- Local tests show there's a failed test for mash_wrapper that I can look into, but I want to push what I have so far