### PR TITLE
Update allele QC function

### DIFF
--- a/man/allele_qc.Rd
+++ b/man/allele_qc.Rd
@@ -15,6 +15,7 @@ allele_qc(
   remove_strand_ambiguous = TRUE,
   flip_strand = FALSE,
   remove_unmatched = TRUE,
+  remove_same_vars = FALSE,
   target_gwas = TRUE
 )
 }


### PR DESCRIPTION
1. Make the logic more clear with more comments. 
2. Nearly always operate in the same dataframe. Guarantee the index can match.
3. Please check fix me: I want to remove the remove_dups parameter since it avoid all multi-allelic sites. Which is unnecessary.
4. The only problem we try to avoid is same variant having different sumstats (eg. z score), I add one parameter remove_same_vars because Derek want to directly get rid of all these variants instead of adding a preprocessing step. This will be defalut set as FALSE to let the user decide if there are case that i mentioned. (I prefer to still use remove_dups parameter but function here)
5. We've tested on many examples and seems work fine!