### PR TITLE
Update vignettes to build

### DIFF
--- a/man/bayes_a_rss_weights.Rd
+++ b/man/bayes_a_rss_weights.Rd
@@ -4,7 +4,7 @@
 \alias{bayes_a_rss_weights}
 \title{Use t-distribution as prior.}
 \usage{
-bayes_a_rss_weights(stat, LD, ...)
+bayes_a_rss_weights(sumstats, LD, ...)
 }
 \description{
 Use t-distribution as prior.

--- a/man/bayes_alphabet_rss_weights.Rd
+++ b/man/bayes_alphabet_rss_weights.Rd
@@ -4,7 +4,7 @@
 \alias{bayes_alphabet_rss_weights}
 \title{Extract weights from gbayes_rss function}
 \usage{
-bayes_alphabet_rss_weights(stat, LD, method, ...)
+bayes_alphabet_rss_weights(sumstats, LD, method, ...)
 }
 \value{
 A numeric vector of the posterior mean of the coefficients.

--- a/man/bayes_c_rss_weights.Rd
+++ b/man/bayes_c_rss_weights.Rd
@@ -4,7 +4,7 @@
 \alias{bayes_c_rss_weights}
 \title{Use a rounded spike prior (low-variance Gaussian).}
 \usage{
-bayes_c_rss_weights(stat, LD, ...)
+bayes_c_rss_weights(sumstats, LD, ...)
 }
 \description{
 Use a rounded spike prior (low-variance Gaussian).

--- a/man/bayes_l_rss_weights.Rd
+++ b/man/bayes_l_rss_weights.Rd
@@ -4,7 +4,7 @@
 \alias{bayes_l_rss_weights}
 \title{Use laplace/double exponential distribution as prior. This is equivalent to Bayesian LASSO.}
 \usage{
-bayes_l_rss_weights(stat, LD, ...)
+bayes_l_rss_weights(sumstats, LD, ...)
 }
 \description{
 Use laplace/double exponential distribution as prior. This is equivalent to Bayesian LASSO.

--- a/man/bayes_n_rss_weights.Rd
+++ b/man/bayes_n_rss_weights.Rd
@@ -4,7 +4,7 @@
 \alias{bayes_n_rss_weights}
 \title{Use Gaussian distribution as prior. Posterior means will be BLUP, equivalent to Ridge Regression.}
 \usage{
-bayes_n_rss_weights(stat, LD, ...)
+bayes_n_rss_weights(sumstats, LD, ...)
 }
 \description{
 Use Gaussian distribution as prior. Posterior means will be BLUP, equivalent to Ridge Regression.

--- a/man/bayes_r_rss_weights.Rd
+++ b/man/bayes_r_rss_weights.Rd
@@ -5,7 +5,7 @@
 \title{Use a hierarchical Bayesian mixture model with four Gaussian components. Variances are scaled
 by 0, 0.0001 , 0.001 , and 0.01 .}
 \usage{
-bayes_r_rss_weights(stat, LD, ...)
+bayes_r_rss_weights(sumstats, LD, ...)
 }
 \description{
 Use a hierarchical Bayesian mixture model with four Gaussian components. Variances are scaled

--- a/man/gbayes_rss.Rd
+++ b/man/gbayes_rss.Rd
@@ -5,9 +5,9 @@
 \title{Bayesian linear regression using summary statistics}
 \usage{
 gbayes_rss(
-  stat = NULL,
+  sumstats = NULL,
   LD = NULL,
-  rsids = NULL,
+  variant_ids = NULL,
   nit = 100,
   nburn = 0,
   nthin = 4,
@@ -39,13 +39,13 @@ gbayes_rss(
 )
 }
 \arguments{
-\item{stat}{dataframe with marker summary statistics. Required: beta coefficient (b), standard error 
-of the beta coefficient (seb), GWAS sample size (n). Optional: rsids, alleles (a1 and a2), 
-major allele frequency (af).}
+\item{sumstats}{dataframe with marker summary statistics. Required: beta coefficient (beta), standard
+error of the beta coefficient (se), GWAS sample size (n). Optional: variant_id or rsid, alleles (A1
+and A2), minor allele frequency (maf).}
 
 \item{LD}{is a the LD matrix corresponding to the same markers as in the stat dataframe}
 
-\item{rsids}{is an optional character vector of rsids, provided outside of the stat dataframe}
+\item{variant_ids}{is an optional character vector of variant ids or rsids, provided outside of the rss dataframe}
 
 \item{nit}{is the number of iterations}
 

--- a/vignettes/cis-analysis.Rmd
+++ b/vignettes/cis-analysis.Rmd
@@ -1,11 +1,10 @@
-
 ---
 title: "cis-QTL analysis and GWAS integration workflow"
 author: "Anqi Wang and Gao Wang"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{intro-to-pecotmr}
+  %\VignetteIndexEntry{cis-QTL analysis and GWAS integration workflow}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -20,7 +19,7 @@ Load the `pecotmr` package.
 
 ```{r load-pkgs}
 library(pecotmr)
-
+```
 
 ## Load data
 

--- a/vignettes/mrmash-intro.Rmd
+++ b/vignettes/mrmash-intro.Rmd
@@ -96,16 +96,15 @@ analysis.
 
 
 ```{r}
-methods <- list(mrmash_weights = list())
-weight <- twas_weights_cv(X=X,Y=Y,fold=5, mrmash_weights_prior_matrices=prior_matrices_cv, 
-                            weight_methods=methods)
+methods <- list(mrmash_weights = list(data_driven_prior_matrices=prior_matrices))
+weight <- twas_weights_cv(X=X,Y=Y,fold=5, weight_methods=methods)
 ```
 
 In the case of providing `sample_partitions`. 
 
 ```{r}
-methods <- list(mrmash_weights = list())
-weight_cv <- twas_weights_cv(X=X,Y=Y, mrmash_weights_prior_matrices=prior_matrices_cv, 
+methods <- list(mrmash_weights = list(data_driven_prior_matrices=prior_matrices))
+weight_cv <- twas_weights_cv(X=X,Y=Y, 
                           sample_partition=sample_partition, weight_methods=methods)
 
 str(weight_cv)
@@ -137,11 +136,7 @@ We will then compute weights for these selected genes for TWAS analysis.
 Here we compute weight for imputable genes without cross-validation. 
 
 ```{r}
-weight_methods <- list(
-    mrmash_weights = list(
-    prior_data_driven_matrices=prior_matrices
-    )
-  )
+weight_methods <- list(mrmash_weights = list(data_driven_prior_matrices=prior_matrices))
     
 weight <- twas_weights(X=X,Y=Y,weight_methods=weight_methods)
  

--- a/vignettes/qtl-gwas-resources.Rmd
+++ b/vignettes/qtl-gwas-resources.Rmd
@@ -4,7 +4,7 @@ author: "Gao Wang"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{intro-to-pecotmr}
+  %\VignetteIndexEntry{Publicly available QTL and GWAS summary statistics resources}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/susie-rss-qc.Rmd
+++ b/vignettes/susie-rss-qc.Rmd
@@ -1,6 +1,10 @@
 ---
 title: "SuSiE RSS with QC"
-output: html_document
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{SuSiE RSS with QC}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 date: "2023-12-17"
 ---
 
@@ -22,7 +26,7 @@ library(pecotmr)
 
 For given region of interest, we load the LD matrix and corresponding summary statistics data, where the summary statistics data should be a data frame with the columns "chrom" and "pos":
 
-```{r}
+```{r AD_GWAS sumstats}
 library(data.table)
 library(dplyr)
 #### Load LD_meta_file
@@ -33,12 +37,19 @@ path = c(paste0("/home/aw3600/MR_KMT_analysis/test/chr8_25007602_26225312.cor.xz
 region  = data.frame(chrom = 8,start = 26220000,end = 26225400)
 #### Load GWAS summary statistics
 AD_GWAS_path = "/mnt/vast/hpc/csg/xqtl_workflow_testing/ADGWAS/data_intergration/ADGWAS2022/ADGWAS_Bellenguez_2022.8/ADGWAS2022.chr8.sumstat.tsv"
-sumstats = fread(AD_GWAS_path)%>%rename("pos"="position")%>%rename("chrom"="chromosome")%>%mutate(z=beta/se)%>%rename("A1"="ref","A2"="alt")
+sumstats = fread(AD_GWAS_path) %>%
+    rename("pos"="position") %>%
+    rename("chrom"="chromosome") %>%
+    mutate(z=beta/se) %>%
+    rename("A1"="ref","A2"="alt")
 ```
 Then extract the LD matrix based on the `LD_meta_file`, `region` and `sumstats`,
-```{r}
-LD_data = load_LD_matrix(LD_meta_file, region, sumstats)
-LD_data[[1]]$LD[1:5,1:5]
+```{r load LD matrix}
+LD_meta_file_path = tempfile(fileext = ".csv")
+write.csv(LD_meta_file, LD_meta_file_path, row.names=FALSE)
+
+LD_data = load_LD_matrix(LD_meta_file_path, region, sumstats)
+LD_data$combined_LD_matrix[1:5,1:5]
 ```
 
 The output LD_data is a list contains the `LD` and `variants_df`, where the `variants_df` is a data frame with the columns "chr","variants","GD(genetic distance)"," pos","A1" and "A2" in a format of bim file. The row and column names of LD are identical to the elements of the `variants` in the data frame `variants_df`. The `variants_df` will be the input of `allele_qc` as the reference panel data.
@@ -47,8 +58,8 @@ The output LD_data is a list contains the `LD` and `variants_df`, where the `var
 
 Match summary statistics data and `variants_df` by ("chr", "A1", "A2" and "pos"), accounting for possible strand flips and major/minor allele flips (opposite effects and zscores). We need to ensure that the format of summary statistics data with the columns "chr", "pos", "A1" and "A2". Because some end positions of one LD block are input positions of another LD block, we will keep these variants after allele flip by setting the parameters `remove_dups` as "FALSE".
 
-```{r}
-allele_fip = allele_qc(sumstats, LD_data[[1]]$variants_df, match.min.prop=0.2, remove_dups=FALSE, flip=TRUE, remove=TRUE)
+```{r allele_qc}
+allele_flip = allele_qc(sumstats$variant, LD_data$combined_LD_variants, sumstats, match_min_prop=0.2, remove_dups=FALSE, flip_strand=TRUE)
 head(allele_flip)
 ```
 
@@ -56,13 +67,11 @@ The output `allele_flip` will be the summary statistics after allele flip.
 
 Because we match sumstats and `LD_data[[1]]$variants_df` by chrom and position after ``allele_qc` step, we need to use the variants of output to extract the `LD.data[[1]]$LD`.
 
-```{r}
-library(dplyr)
-allele_flip = allele_flip %>% mutate(variant_allele_flip = paste(chrom,pos,A1.sumstats,A2.sumstats,sep=":"))
-LD_extract = LD_data[[1]]$LD[allele_flip$variant_allele_flip,allele_flip$variant_allele_flip]
+```{r qc LD}
+LD_extract = LD_data$combined_LD_matrix[allele_flip$target_data_qced$variant_id,allele_flip$target_data_qced$variant_id]
 ```
 ## run SuSiE RSS:
-```{r}
+```{r susie rss}
 library(susieR)
-res = susie_rss(allele_flip$z, LD_extract)
+res = susie_rss(allele_flip$target_data_qced$z, LD_extract)
 ```


### PR DESCRIPTION
I have made modifications to susie-rss-qc.Rmd and  mrmash-intro.Rmd that allow these vignettes to build. I have also aligned the YAML header and VignetteIndex of qtl-gwas-resources.Rmd to resolve warnings with that vignette. There are still unresolved issues with the file locations for cis-analysis.Rmd.

This PR also contains minor changes to the gbayes RSS functions, changing the name of the summary statistics dataframe and variables to match those in other pecotmr functions:
RSS dataframe: stat --> sumstats
- beta coefficient: b --> beta
- beta standard error: seb --> se
- alleles: a1, a2 --> A1, A2
- minor allele frequence: eaf --> maf