### PR TITLE
fix quantile_twas_weight colnames missing issue

### DIFF
--- a/man/mrmash_wrapper.Rd
+++ b/man/mrmash_wrapper.Rd
@@ -7,6 +7,7 @@
 mrmash_wrapper(
   X,
   Y,
+  V = NULL,
   sumstats = NULL,
   data_driven_prior_matrices = NULL,
   prior_grid = NULL,


### PR DESCRIPTION
# FIX Error 1: LD Clumping and Pruning Error

## Issue:
When performing LD clumping and pruning from QR screen results, the following error occurred:  
Error: invalid assignment for reference class field ‘nrow’, should be from class “numeric” or a subclass (was class “NULL”)

## Cause:
This error occurs when the union of SNPs after LD clumping contains only one SNP. Since there is only one SNP, the process cannot proceed to LD pruning, which requires more than one SNP.

## Solution:
To fix this, I modified the process so that when only one SNP remains after LD clumping, the function directly returns the final SNPs without attempting LD pruning.

---

# FIX Error 2: check_remove_highcorr_snp and Missing `dimnames`

## Issue:
When processing check_remove_highcorr_snp, the following error occurred:  
Error in dimnames(x) <- dn :
length of 'dimnames' [2] not equal to array extent
Calls: quantile_twas_weight_pipeline ... calculate_qr_and_pseudo_R2 -> check_remove_highcorr_snp -> colnames<-

## Cause:
This error happens when only one SNP passes the `corr_filter` function. In such cases, the column name of `X_filter` is lost, leading to a mismatch in the dimensions.

## Solution:
To resolve this, I ensured that when a matrix contains only one column, the column name is preserved. This prevents the loss of `colnames` in cases where only one SNP passes through the filter.

---

# Additional Improvements:
In addition to fixing these two issues, I reviewed other functions to ensure that `colnames` and `rownames` are consistently preserved, especially in cases where the matrix has only one column or row.


