### PR TITLE
add corr_filter() when it is still not full rank after removing all problematic snps

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,21 +2,22 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 dentist_iterative_impute <- function(LD_mat, nSample, zScore, pValueThreshold, propSVD, gcControl, nIter, gPvalueThreshold, ncpus, seed, correct_chen_et_al_bug, verbose = FALSE) {
-  .Call("_pecotmr_dentist_iterative_impute", PACKAGE = "pecotmr", LD_mat, nSample, zScore, pValueThreshold, propSVD, gcControl, nIter, gPvalueThreshold, ncpus, seed, correct_chen_et_al_bug, verbose)
+    .Call('_pecotmr_dentist_iterative_impute', PACKAGE = 'pecotmr', LD_mat, nSample, zScore, pValueThreshold, propSVD, gcControl, nIter, gPvalueThreshold, ncpus, seed, correct_chen_et_al_bug, verbose)
 }
 
 rcpp_mr_ash_rss <- function(bhat, shat, z, R, var_y, n, sigma2_e, s0, w0, mu1_init, tol = 1e-8, max_iter = 1e5L, update_w0 = TRUE, update_sigma = TRUE, compute_ELBO = TRUE, standardize = FALSE, ncpus = 1L) {
-  .Call("_pecotmr_rcpp_mr_ash_rss", PACKAGE = "pecotmr", bhat, shat, z, R, var_y, n, sigma2_e, s0, w0, mu1_init, tol, max_iter, update_w0, update_sigma, compute_ELBO, standardize, ncpus)
+    .Call('_pecotmr_rcpp_mr_ash_rss', PACKAGE = 'pecotmr', bhat, shat, z, R, var_y, n, sigma2_e, s0, w0, mu1_init, tol, max_iter, update_w0, update_sigma, compute_ELBO, standardize, ncpus)
 }
 
 prs_cs_rcpp <- function(a, b, phi, bhat, maf, n, ld_blk, n_iter, n_burnin, thin, verbose, seed) {
-  .Call("_pecotmr_prs_cs_rcpp", PACKAGE = "pecotmr", a, b, phi, bhat, maf, n, ld_blk, n_iter, n_burnin, thin, verbose, seed)
+    .Call('_pecotmr_prs_cs_rcpp', PACKAGE = 'pecotmr', a, b, phi, bhat, maf, n, ld_blk, n_iter, n_burnin, thin, verbose, seed)
 }
 
 qtl_enrichment_rcpp <- function(r_gwas_pip, r_qtl_susie_fit, pi_gwas = 0, pi_qtl = 0, ImpN = 25L, shrinkage_lambda = 1.0, num_threads = 1L) {
-  .Call("_pecotmr_qtl_enrichment_rcpp", PACKAGE = "pecotmr", r_gwas_pip, r_qtl_susie_fit, pi_gwas, pi_qtl, ImpN, shrinkage_lambda, num_threads)
+    .Call('_pecotmr_qtl_enrichment_rcpp', PACKAGE = 'pecotmr', r_gwas_pip, r_qtl_susie_fit, pi_gwas, pi_qtl, ImpN, shrinkage_lambda, num_threads)
 }
 
 sdpr_rcpp <- function(bhat, LD, n, per_variant_sample_size = NULL, array = NULL, a = 0.1, c = 1.0, M = 1000L, a0k = 0.5, b0k = 0.5, iter = 1000L, burn = 200L, thin = 5L, n_threads = 1L, opt_llk = 1L, verbose = TRUE) {
-  .Call("_pecotmr_sdpr_rcpp", PACKAGE = "pecotmr", bhat, LD, n, per_variant_sample_size, array, a, c, M, a0k, b0k, iter, burn, thin, n_threads, opt_llk, verbose)
+    .Call('_pecotmr_sdpr_rcpp', PACKAGE = 'pecotmr', bhat, LD, n, per_variant_sample_size, array, a, c, M, a0k, b0k, iter, burn, thin, n_threads, opt_llk, verbose)
 }
+

--- a/man/qr_screen.Rd
+++ b/man/qr_screen.Rd
@@ -8,9 +8,9 @@ qr_screen(
   X,
   Y,
   Z = NULL,
-  tau.list,
-  threshold = 0.05,
-  method = "qvalue",
+  tau.list = seq(0.05, 0.95, by = 0.05),
+  screen_threshold = 0.05,
+  screen_method = "qvalue",
   top_count = 10,
   top_percent = 15
 )
@@ -24,9 +24,9 @@ qr_screen(
 
 \item{tau.list}{Vector of quantiles to be analyzed}
 
-\item{threshold}{Significance threshold for adjusted p-values}
+\item{screen_threshold}{Significance threshold for adjusted p-values}
 
-\item{method}{Method for p-value adjustment ('fdr' or 'qvalue')}
+\item{screen_method}{Method for p-value adjustment ('fdr' or 'qvalue')}
 
 \item{top_count}{Number of top SNPs to select}
 

--- a/man/quantile_twas_weight_pipeline.Rd
+++ b/man/quantile_twas_weight_pipeline.Rd
@@ -9,9 +9,9 @@ quantile_twas_weight_pipeline(
   Y,
   Z = NULL,
   maf = NULL,
-  extract_region_name,
+  region_id = "",
   ld_reference_meta_file = NULL,
-  maf_cutoff = 0.01,
+  twas_maf_cutoff = 0.01,
   quantile_qtl_tau_list = seq(0.05, 0.95, by = 0.05),
   quantile_twas_tau_list = seq(0.01, 0.99, by = 0.01)
 )
@@ -25,7 +25,7 @@ quantile_twas_weight_pipeline(
 
 \item{maf}{Vector of minor allele frequencies (optional)}
 
-\item{extract_region_name}{Name of the region being analyzed}
+\item{region_id}{Name of the region being analyzed}
 
 \item{quantile_qtl_tau_list}{Vector of quantiles for QTL analysis}
 
@@ -59,6 +59,6 @@ The function performs the following steps:
 # X <- matrix of genotypes
 # Y <- vector of phenotypes
 # Z <- matrix of covariates
-# results <- quantile_twas_weight_pipeline(X, Y, Z, extract_region_name = "GeneA")
+# results <- quantile_twas_weight_pipeline(X, Y, Z, region_id = "GeneA")
 
 }


### PR DESCRIPTION
1. In some datasets with a large number of SNPs, especially when the difference between the rank and the number of columns is significant, the design matrix remains not full rank even after removing all problematic SNPs. This is because the covariates were also being identified as problematic columns.

2. To address this issue, I added a check: if the matrix remains not full rank in such cases, a corr_filter is applied to the remaining SNPs, starting with a threshold of 0.75. If it is still not full rank, the threshold is lowered by 0.05 each time until the matrix becomes full rank or the threshold reaches 0.5.