### PR TITLE
update rss_finemapping part

### DIFF
--- a/R/file_utils.R
+++ b/R/file_utils.R
@@ -762,7 +762,7 @@ load_twas_weights <- function(weight_db_files, conditions = NULL,
 #' @param region The region where tabix use to subset the input dataset.
 #' @param target User-specified gene/phenotype name used to further subset the phenotype data.
 #' @param target_column_index Filter this specific column for the target.
-#' @param no_comment whether to consider all content after '#' as comment in the column_mapping file.
+#' @param comment_string comment sign in the column_mapping file, default is #
 #' @return A list of rss_input, including the column-name-formatted summary statistics,
 #' sample size (n), and var_y.
 #'
@@ -771,9 +771,9 @@ load_twas_weights <- function(weight_db_files, conditions = NULL,
 #' @importFrom data.table fread
 #' @export
 load_rss_data <- function(sumstat_path, column_file_path, subset = TRUE, n_sample = 0, n_case = 0, n_control = 0, target = "",
-                          region = "", target_column_index = "", no_comment = FALSE) {
+                          region = "", target_column_index = "", comment_string = "#") {
   # Read and preprocess column mapping
-  if(no_comment) {
+  if (is.null(comment_string)) {
     column_data <- read.table(column_file_path, 
                               header = FALSE, sep = ":", 
                               comment.char = "",  # This tells R not to treat any character as comment
@@ -782,6 +782,7 @@ load_rss_data <- function(sumstat_path, column_file_path, subset = TRUE, n_sampl
   } else {
     column_data <- read.table(column_file_path, 
                               header = FALSE, sep = ":", 
+                              comment.char = comment_string,
                               stringsAsFactors = FALSE) %>%
       rename(standard = V1, original = V2)
   }

--- a/R/file_utils.R
+++ b/R/file_utils.R
@@ -762,6 +762,7 @@ load_twas_weights <- function(weight_db_files, conditions = NULL,
 #' @param region The region where tabix use to subset the input dataset.
 #' @param target User-specified gene/phenotype name used to further subset the phenotype data.
 #' @param target_column_index Filter this specific column for the target.
+#' @param no_comment whether to consider all content after '#' as comment in the column_mapping file.
 #' @return A list of rss_input, including the column-name-formatted summary statistics,
 #' sample size (n), and var_y.
 #'
@@ -769,10 +770,21 @@ load_twas_weights <- function(weight_db_files, conditions = NULL,
 #' @importFrom magrittr %>%
 #' @importFrom data.table fread
 #' @export
-load_rss_data <- function(sumstat_path, column_file_path, subset = TRUE, n_sample = 0, n_case = 0, n_control = 0, target = "", region = "", target_column_index = "") {
+load_rss_data <- function(sumstat_path, column_file_path, subset = TRUE, n_sample = 0, n_case = 0, n_control = 0, target = "",
+                          region = "", target_column_index = "", no_comment = FALSE) {
   # Read and preprocess column mapping
-  column_data <- read.table(column_file_path, header = FALSE, sep = ":", stringsAsFactors = FALSE) %>%
-    rename(standard = V1, original = V2)
+  if(no_comment) {
+    column_data <- read.table(column_file_path, 
+                              header = FALSE, sep = ":", 
+                              comment.char = "",  # This tells R not to treat any character as comment
+                              stringsAsFactors = FALSE) %>%
+      rename(standard = V1, original = V2)
+  } else {
+    column_data <- read.table(column_file_path, 
+                              header = FALSE, sep = ":", 
+                              stringsAsFactors = FALSE) %>%
+      rename(standard = V1, original = V2)
+  }
 
   # Initialize sumstats variable
   sumstats <- NULL

--- a/R/susie_wrapper.R
+++ b/R/susie_wrapper.R
@@ -317,10 +317,10 @@ get_cs_info <- function(susie_output_sets_cs, top_variants_idx) {
 #' @noRd
 get_cs_and_corr <- function(susie_output, coverage, data_x, mode = c("susie", "susie_rss", "mvsusie"), min_abs_corr = NULL, median_abs_corr = NULL) {
   if (mode %in% c("susie", "mvsusie")) {
-    susie_output_secondary <- list(sets = susie_get_cs(susie_output, X = data_x, coverage = coverage, min_abs_corr = min_abs_corr), pip = susie_output$pip)
+    susie_output_secondary <- list(sets = susie_get_cs(susie_output, X = data_x, coverage = coverage, min_abs_corr = min_abs_corr, median_abs_corr = median_abs_corr), pip = susie_output$pip)
     susie_output_secondary$cs_corr <- get_cs_correlation(susie_output_secondary, X = data_x)
   } else {
-    susie_output_secondary <- list(sets = susie_get_cs(susie_output, Xcorr = data_x, coverage = coverage, min_abs_corr = min_abs_corr), pip = susie_output$pip)
+    susie_output_secondary <- list(sets = susie_get_cs(susie_output, Xcorr = data_x, coverage = coverage, min_abs_corr = min_abs_corr, median_abs_corr = median_abs_corr), pip = susie_output$pip)
     susie_output_secondary$cs_corr <- get_cs_correlation(susie_output_secondary, Xcorr = data_x)
   }
   susie_output_secondary
@@ -403,7 +403,7 @@ susie_post_processor <- function(susie_output, data_x, data_y, X_scalar, y_scala
     sets_secondary <- list()
     if (!is.null(secondary_coverage) && length(secondary_coverage)) {
       for (sec_cov in secondary_coverage) {
-        sets_secondary[[paste0("coverage_", sec_cov)]] <- get_cs_and_corr(susie_output, sec_cov, data_x, mode, min_abs_corr, median_abs_corr)
+        sets_secondary[[paste0("coverage_", sec_cov)]] <- get_cs_and_corr(susie_output, sec_cov, data_x, mode, min_abs_corr, median_abs_corr=median_abs_corr)
         top_variants_idx_sec <- get_top_variants_idx(sets_secondary[[paste0("coverage_", sec_cov)]], signal_cutoff)
         cs_sec <- get_cs_info(sets_secondary[[paste0("coverage_", sec_cov)]]$sets$cs, top_variants_idx_sec)
         top_loci_list[[paste0("coverage_", sec_cov)]] <- data.frame(variant_idx = top_variants_idx_sec, cs_idx = cs_sec, stringsAsFactors = FALSE)

--- a/R/susie_wrapper.R
+++ b/R/susie_wrapper.R
@@ -151,7 +151,7 @@ susie_wrapper <- function(X, y, init_L = 5, max_L = 30, l_step = 5, ...) {
 #' @importFrom susieR susie_rss
 #' @export
 susie_rss_wrapper <- function(z, R, n = NULL, var_y = NULL, L = 10, max_L = 30, l_step = 5,
-                              zR_discrepancy_correction = FALSE, coverage = 0.95, ...) {
+                              zR_discrepancy_correction = FALSE, coverage = 0.95, median_abs_corr = NULL, ...) {
   if (L == 1) {
     return(susie_rss(
       z = z, R = R, var_y = var_y, n = n,
@@ -317,10 +317,10 @@ get_cs_info <- function(susie_output_sets_cs, top_variants_idx) {
 #' @noRd
 get_cs_and_corr <- function(susie_output, coverage, data_x, mode = c("susie", "susie_rss", "mvsusie"), min_abs_corr = NULL, median_abs_corr = NULL) {
   if (mode %in% c("susie", "mvsusie")) {
-    susie_output_secondary <- list(sets = susie_get_cs(susie_output, X = data_x, coverage = coverage, min_abs_corr = min_abs_corr, median_abs_corr = median_abs_corr), pip = susie_output$pip)
+    susie_output_secondary <- list(sets = susie_get_cs(susie_output, X = data_x, coverage = coverage, min_abs_corr = min_abs_corr), pip = susie_output$pip)
     susie_output_secondary$cs_corr <- get_cs_correlation(susie_output_secondary, X = data_x)
   } else {
-    susie_output_secondary <- list(sets = susie_get_cs(susie_output, Xcorr = data_x, coverage = coverage, min_abs_corr = min_abs_corr, median_abs_corr = median_abs_corr), pip = susie_output$pip)
+    susie_output_secondary <- list(sets = susie_get_cs(susie_output, Xcorr = data_x, coverage = coverage, min_abs_corr = min_abs_corr), pip = susie_output$pip)
     susie_output_secondary$cs_corr <- get_cs_correlation(susie_output_secondary, Xcorr = data_x)
   }
   susie_output_secondary

--- a/R/univariate_pipeline.R
+++ b/R/univariate_pipeline.R
@@ -179,12 +179,12 @@ rss_analysis_pipeline <- function(
       coverage = c(0.95, 0.7, 0.5), signal_cutoff = 0.025
     ),
     impute = TRUE, impute_opts = list(rcond = 0.01, R2_threshold = 0.6, minimum_ld = 5, lamb = 0.01),
-    pip_cutoff_to_skip = 0, remove_indels = FALSE, no_comment = FALSE) {
+    pip_cutoff_to_skip = 0, remove_indels = FALSE, comment_string = "#") {
   res <- list()
   rss_input <- load_rss_data(
     sumstat_path = sumstat_path, column_file_path = column_file_path,
     n_sample = n_sample, n_case = n_case, n_control = n_control, target = target, region = region,
-      target_column_index = target_column_index, no_comment = no_comment
+      target_column_index = target_column_index, comment_string = comment_string
   )
 
   sumstats <- rss_input$sumstats

--- a/R/univariate_pipeline.R
+++ b/R/univariate_pipeline.R
@@ -179,11 +179,12 @@ rss_analysis_pipeline <- function(
       coverage = c(0.95, 0.7, 0.5), signal_cutoff = 0.025
     ),
     impute = TRUE, impute_opts = list(rcond = 0.01, R2_threshold = 0.6, minimum_ld = 5, lamb = 0.01),
-    pip_cutoff_to_skip = 0, remove_indels = FALSE) {
+    pip_cutoff_to_skip = 0, remove_indels = FALSE, no_comment = FALSE) {
   res <- list()
   rss_input <- load_rss_data(
     sumstat_path = sumstat_path, column_file_path = column_file_path,
-    n_sample = n_sample, n_case = n_case, n_control = n_control, target = target, region = region, target_column_index = target_column_index
+    n_sample = n_sample, n_case = n_case, n_control = n_control, target = target, region = region,
+      target_column_index = target_column_index, no_comment = no_comment
   )
 
   sumstats <- rss_input$sumstats

--- a/man/load_rss_data.Rd
+++ b/man/load_rss_data.Rd
@@ -14,7 +14,7 @@ load_rss_data(
   target = "",
   region = "",
   target_column_index = "",
-  no_comment = FALSE
+  comment_string = "#"
 )
 }
 \arguments{
@@ -34,7 +34,7 @@ load_rss_data(
 
 \item{target_column_index}{Filter this specific column for the target.}
 
-\item{no_comment}{whether to consider all content after '#' as comment in the column_mapping file.}
+\item{comment_string}{comment sign in the column_mapping file, default is #}
 }
 \value{
 A list of rss_input, including the column-name-formatted summary statistics,

--- a/man/load_rss_data.Rd
+++ b/man/load_rss_data.Rd
@@ -13,7 +13,8 @@ load_rss_data(
   n_control = 0,
   target = "",
   region = "",
-  target_column_index = ""
+  target_column_index = "",
+  no_comment = FALSE
 )
 }
 \arguments{
@@ -32,6 +33,8 @@ load_rss_data(
 \item{region}{The region where tabix use to subset the input dataset.}
 
 \item{target_column_index}{Filter this specific column for the target.}
+
+\item{no_comment}{whether to consider all content after '#' as comment in the column_mapping file.}
 }
 \value{
 A list of rss_input, including the column-name-formatted summary statistics,

--- a/man/rss_analysis_pipeline.Rd
+++ b/man/rss_analysis_pipeline.Rd
@@ -23,7 +23,7 @@ rss_analysis_pipeline(
   impute_opts = list(rcond = 0.01, R2_threshold = 0.6, minimum_ld = 5, lamb = 0.01),
   pip_cutoff_to_skip = 0,
   remove_indels = FALSE,
-  no_comment = FALSE
+  comment_string = "#"
 )
 }
 \arguments{

--- a/man/rss_analysis_pipeline.Rd
+++ b/man/rss_analysis_pipeline.Rd
@@ -22,7 +22,8 @@ rss_analysis_pipeline(
   impute = TRUE,
   impute_opts = list(rcond = 0.01, R2_threshold = 0.6, minimum_ld = 5, lamb = 0.01),
   pip_cutoff_to_skip = 0,
-  remove_indels = FALSE
+  remove_indels = FALSE,
+  no_comment = FALSE
 )
 }
 \arguments{

--- a/man/susie_rss_wrapper.Rd
+++ b/man/susie_rss_wrapper.Rd
@@ -14,6 +14,7 @@ susie_rss_wrapper(
   l_step = 5,
   zR_discrepancy_correction = FALSE,
   coverage = 0.95,
+  median_abs_corr = NULL,
   ...
 )
 }


### PR DESCRIPTION
1. Added a parameter no_comment to decide whether to to consider all content after '#' as comment in the column_mapping file(need corresponding modifications in rss_analysis.ipynb)
2. Fixed the `unused argument median_abs_corr = median_abs_corr`  error in some phenotypes
3. Tested and the output looked fine.