### PR TITLE
modify univariate_analysis_pipeline, adding the estimate_prior_method parameter(WIP)

### DIFF
--- a/R/susie_wrapper.R
+++ b/R/susie_wrapper.R
@@ -104,9 +104,9 @@ adjust_susie_weights <- function(twas_weights_results, keep_variants, allele_qc 
 
 #' @importFrom susieR susie
 #' @export
-susie_wrapper <- function(X, y, init_L = 5, max_L = 30, l_step = 5, ...) {
+susie_wrapper <- function(X, y, init_L = 5, max_L = 30, l_step = 5, estimate_prior_method = NULL, ...) {
   if (init_L == max_L) {
-    return(susie(X, y, L = init_L, median_abs_corr = 0.8, ...))
+    return(susie(X, y, L = init_L, median_abs_corr = 0.8, estimate_prior_method =estimate_prior_method, ...))
   }
   L <- init_L
   # Perform SuSiE by dynamically increasing L
@@ -115,7 +115,7 @@ susie_wrapper <- function(X, y, init_L = 5, max_L = 30, l_step = 5, ...) {
     st <- proc.time()
     res <- susie(X, y,
       L = L,
-      median_abs_corr = 0.8, ...
+      median_abs_corr = 0.8, estimate_prior_method =estimate_prior_method, ...
     )
     res$time_elapsed <- proc.time() - st
     if (!is.null(res$sets$cs)) {

--- a/R/univariate_pipeline.R
+++ b/R/univariate_pipeline.R
@@ -26,6 +26,7 @@
 #' @param cv_folds The number of folds to use for cross-validation. Default is 5.
 #' @param cv_threads The number of threads to use for parallel computation in cross-validation. Default is 1.
 #' @param verbose Verbosity level. Default is 0.
+#' @para estimate_prior_method Estimate_prior_method that will be passed to susie_wrapper and then to susie(). Default is NULL.
 #'
 #' @return A list containing the univariate analysis results.
 #' @importFrom susieR susie
@@ -58,7 +59,8 @@ univariate_analysis_pipeline <- function(
     max_cv_variants = -1,
     cv_folds = 5,
     cv_threads = 1,
-    verbose = 0) {
+    verbose = 0,
+    estimate_prior_method = NULL) {
   # Input validation
   if (!is.matrix(X) || !is.numeric(X)) stop("X must be a numeric matrix")
   if (!is.vector(Y) && !(is.matrix(Y) && ncol(Y) == 1) || !is.numeric(Y)) stop("Y must be a numeric vector or a single column matrix")
@@ -111,7 +113,7 @@ univariate_analysis_pipeline <- function(
   message("Fitting SuSiE model on input data with L optimization...")
   res$susie_fitted <- susie_wrapper(X, Y,
     init_L = init_L, max_L = max_L, l_step = l_step,
-    refine = TRUE, coverage = coverage[1]
+    refine = TRUE, coverage = coverage[1], estimate_prior_method = estimate_prior_method
   )
 
   # Process SuSiE results

--- a/man/univariate_analysis_pipeline.Rd
+++ b/man/univariate_analysis_pipeline.Rd
@@ -27,7 +27,8 @@ univariate_analysis_pipeline(
   max_cv_variants = -1,
   cv_folds = 5,
   cv_threads = 1,
-  verbose = 0
+  verbose = 0,
+  estimate_prior_method = NULL
 )
 }
 \arguments{


### PR DESCRIPTION
I tried to apply the additional parameter from susieRsmall to the pecotmr along with the finemapping pipeline. But I got some issues as follows:
1. I got below error when running susie twas for `ADAM17` using `EM` method.
```
Error in if (!all(diff(res$elbo) >= (-1 * warning_tol))) warning("Objective is decreasing") : 
  missing value where TRUE/FALSE needed
Calls: lapply ... susie -> sapply -> lapply -> FUN -> susie_get_objective
Execution halted
```

2. The running time for one gene task takes much more time, which is around one hour. Maybe we can decrease the iteration num considering that William can get reasonable cs num using `max_iter = 20` .